### PR TITLE
Cai: change the mcce executable file path

### DIFF
--- a/submit.sh
+++ b/submit.sh
@@ -16,4 +16,4 @@
 #$ -e error.log
 
 # Now comes the commands to be executed
-/home/mcce/mcce2.5.1/mcce
+/home/mcce/Stable-MCCE/bin/mcce


### PR DESCRIPTION
The original executable file path is wrong, I changed it to the correct one.