### PR TITLE
fixes mac compile error by removing -static in delphi, and commented …

### DIFF
--- a/lib/delphi/makefile
+++ b/lib/delphi/makefile
@@ -1,6 +1,6 @@
 VPATH=src
 #LINUX INTEL
-  FC=gfortran -O3 -static -fcray-pointer -ffixed-line-length-none
+  FC=gfortran -O3 -fcray-pointer -ffixed-line-length-none
   CC=gcc -O3
 #  FC=gfortran -g -static -fcray-pointer -ffixed-line-length-none
 #  CC=gcc -g

--- a/lib/init.c
+++ b/lib/init.c
@@ -748,6 +748,7 @@ int get_env()
             else env.delphi_clean = 0;
         }
         else if (strstr(sbuff, "(PBE_SOLVER)")) {
+             /* This block causes "Trap 6" error on Mac, jmao
              strcpy(sbuff, strtok(sbuff, " "));
              if (strstr(sbuff, "apbs") || strstr(sbuff, "APBS")) {
                 strcpy(env.pbe_solver, "apbs");
@@ -762,6 +763,8 @@ int get_env()
                  printf("\n   Not known PBE solver: \"%s\". Using delphi in step 3...\n", sbuff);
                  strcpy(env.pbe_solver, "delphi");
              }
+             */
+             strcpy(env.pbe_solver, "delphi");
          }
  		else if (strstr(sbuff, "(RXN_METHOD)")) {
              strcpy(sbuff, strtok(sbuff, " "));


### PR DESCRIPTION
…out pbe selection as this block causes run time error.